### PR TITLE
fix: incorrect documentation for SyncoStyle

### DIFF
--- a/RhythmBase/RhythmDoctor/Events/SetRowXs.cs
+++ b/RhythmBase/RhythmDoctor/Events/SetRowXs.cs
@@ -24,7 +24,7 @@ public record class SetRowXs : BaseBeat
 	[RDJsonCondition($"$&.{nameof(SyncoBeat)} >= 0")]
 	public float SyncoSwing { get; set; } = 0;
 	/// <summary>
-	/// Gets or sets the synchronization style for row processing.
+	/// Gets or sets the syncopation beat's cue style.
 	/// </summary>
 	[RDJsonCondition($"$&.{nameof(SyncoBeat)} >= 0")]
 	public SetRowXsSyncoStyle SyncoStyle { get; set; } = SetRowXsSyncoStyle.Chirp;


### PR DESCRIPTION
`SyncoStyle` definitely has absolutely nothing to do with synchronization. Having no clue about how this will even be written down as a comment of `SyncoStyle`. Anyway I fixed it.